### PR TITLE
Change the order in which css styles are loaded

### DIFF
--- a/deploy/media/css/style.css
+++ b/deploy/media/css/style.css
@@ -3263,7 +3263,7 @@ img + .document {
 }
 
 .navbar-nav > li > a:hover {
-	color: #E6940E;
+	color: #FFF;
 }
 
 .dropdown-menu {

--- a/layout/base.j2
+++ b/layout/base.j2
@@ -17,8 +17,8 @@
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-XdYbMnZ/QjLh6iI4ogqCTaIjrFk87ip+ekIjefZch0Y+PvJ8CDYtEs1ipDmPorQ+" crossorigin="anonymous">
     <link href="/media/css/animate.min.css" rel="stylesheet">
-    <link href="/media/css/style.min.css" rel="stylesheet">
     <link href="/media/css/style-jd.min.css" rel="stylesheet">
+    <link href="/media/css/style.min.css" rel="stylesheet">
     <link href="/media/css/pygments.min.css" rel="stylesheet">
     <link href="{{ media_url('css/flag-icon.min.css') }}" rel="stylesheet">
     <link href="//fonts.googleapis.com/css?family=Open+Sans:400,300" rel="stylesheet">


### PR DESCRIPTION
Loading style-jd.css prior to style.css prevents it from overriding hover colors for nav-tabs. This patch fixes an issue where hovering nav tabs in emacs-package page turns the color of the tab white effectively hiding the tab on white background. Moreover, the navbar hovering color is changed to #fff to preserve the prior functionality of navbar. I'm not exactly sure whether white hover color in navbar is intentional as the footer uses #E6940E for hover color.

[The issue is shown here.](https://imgur.com/a/Gvhuq)